### PR TITLE
Add homepage

### DIFF
--- a/mautic.gemspec
+++ b/mautic.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
 
   spec.summary       = %q{Mautic integration for Ruby}
   spec.description   = %q{Mautic Integration}
-  spec.homepage      = "TODO: Put your gem's website or public repo URL here."
+  spec.homepage      = "https://github.com/mfbassora/mautic_ruby"
   spec.license       = "MIT"
 
   # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'


### PR DESCRIPTION
Isso resolve o erro do bundler:
```
You have one or more invalid gemspecs that need to be fixed.
The gemspec at
/home/rof/cache/bundler/ruby/2.3.0/bundler/gems/mautic_ruby-a4952d7680bb/mautic.gemspec
is not valid. Please fix this gemspec.
The validation error was '"TODO: Put your gem's website or public repo URL
here." is not a valid HTTP URI'
```